### PR TITLE
Remove override command for createJSModules

### DIFF
--- a/android/src/main/java/com/wscodelabs/callLogs/CallLogPackage.java
+++ b/android/src/main/java/com/wscodelabs/callLogs/CallLogPackage.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 public class CallLogPackage implements ReactPackage {
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
According to this [documentation](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8), we need to remove the override or else it causes the app to break.

See also [another library's changes](https://github.com/oblador/react-native-vector-icons/issues/515)