### PR TITLE
Add filters: phoneNumbers, minTimestamp, maxTimestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,31 @@ import CallLogs from 'react-native-call-log'
    }
 ```
 
-## Methods 
+## Methods
 Methods       | Description
 ------------- | -------------
-load(LIMIT)   | `LIMIT: number` get maximum number of call logs.  
-loadAll()        | get all call logs 
+`load(LIMIT)`   | `LIMIT: number` get maximum number of call logs.
+`load(limit, filter)` | `LIMIT: number` (use -1 for no limit)<br> `filter`: [see usage here](#filter)
+`loadAll()`        | get all call logs
 
-## Example 
+### Filter call logs
+```
+...
+/* List call logs matching the filter */
+const filter = {
+  minTimestamp: 1571835032,    // (Number or String) timestamp in milliseconds since UNIX epoch
+                               // if this filter is set, load() will only return call logs with timestamp >= minTimestamp
+
+  maxTimestamp: 1571835033,    // (Number or String) timestamp in milliseconds since UNIX epoch
+                               //
+                               // if this filter is set, load() will only return call logs with timestamp <= maxTimestamp
+
+  phoneNumbers: '+1234567890', // (String or an Array of Strings)
+                               // if this filter is set
+}
+
+const callLogs = await CallLogs.load(-1, filter) // applies filter with no limit (also works with a limit)
+...
+```
+## Example
 Clone or download the repository then Run `cd Example && npm install`
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Installation:
 Run `yarn add react-native-call-log`
- 
+
 
 ### Android
 
@@ -43,7 +43,7 @@ dependencies {
 ```javascript
 import { PermissionsAndroid } from 'react-native';
 import CallLogs from 'react-native-call-log'
- 
+
  componentDidMount =  async() => {
     try {
       const granted = await PermissionsAndroid.request(
@@ -74,7 +74,7 @@ import CallLogs from 'react-native-call-log'
 Methods       | Description
 ------------- | -------------
 `load(LIMIT)`   | `LIMIT: number` get maximum number of call logs.
-`load(limit, filter)` | `LIMIT: number` (use -1 for no limit)<br> `filter`: [see usage here](#filter)
+`load(limit, filter)` | `LIMIT: number` (use -1 for no limit)<br> `filter`: [see usage here](#filter-call-logs))
 `loadAll()`        | get all call logs
 
 ### Filter call logs

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ Methods       | Description
 /* List call logs matching the filter */
 const filter = {
   minTimestamp: 1571835032,    // (Number or String) timestamp in milliseconds since UNIX epoch
-                               // if this filter is set, load() will only return call logs with timestamp >= minTimestamp
+                               // if this filter is set, load(limit, filter) will only return call logs with timestamp >= minTimestamp
 
   maxTimestamp: 1571835033,    // (Number or String) timestamp in milliseconds since UNIX epoch
                                //
-                               // if this filter is set, load() will only return call logs with timestamp <= maxTimestamp
+                               // if this filter is set, load(limit, filter) will only return call logs with timestamp <= maxTimestamp
 
-  phoneNumbers: '+1234567890', // (String or an Array of Strings)
-                               // if this filter is set
+  phoneNumbers: '+1234567890', // (String or an Array of String)
+                               // if this filter is set, load(limit, filter) will only return call logs for this/these phone numbers
 }
 
 const callLogs = await CallLogs.load(-1, filter) // applies filter with no limit (also works with a limit)

--- a/android/src/main/java/com/wscodelabs/callLogs/CallLogModule.java
+++ b/android/src/main/java/com/wscodelabs/callLogs/CallLogModule.java
@@ -4,16 +4,12 @@ import android.provider.CallLog;
 import android.provider.CallLog.Calls;
 import android.database.Cursor;
 import android.content.Context;
-import android.util.JsonReader;
-import android.util.Log;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.facebook.react.bridge.Promise;
@@ -21,14 +17,12 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import javax.annotation.Nullable;
 

--- a/android/src/main/java/com/wscodelabs/callLogs/CallLogModule.java
+++ b/android/src/main/java/com/wscodelabs/callLogs/CallLogModule.java
@@ -4,18 +4,33 @@ import android.provider.CallLog;
 import android.provider.CallLog.Calls;
 import android.database.Cursor;
 import android.content.Context;
+import android.util.JsonReader;
+import android.util.Log;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.annotation.Nullable;
 
 public class CallLogModule extends ReactContextBaseJavaModule {
 
@@ -38,51 +53,91 @@ public class CallLogModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void load(int limit, Promise promise) {
-        Cursor cursor = this.context.getContentResolver().query(CallLog.Calls.CONTENT_URI,
-                null, null, null, CallLog.Calls.DATE + " DESC");
+        loadWithFilter(limit, null, promise);
+    }
 
-        WritableArray result = Arguments.createArray();
+    @ReactMethod
+    public void loadWithFilter(int limit, @Nullable ReadableMap filter, Promise promise) {
+        try {
+            Cursor cursor = this.context.getContentResolver().query(CallLog.Calls.CONTENT_URI,
+                    null, null, null, CallLog.Calls.DATE + " DESC");
 
-        if (cursor == null) {
+            WritableArray result = Arguments.createArray();
+
+            if (cursor == null) {
+                promise.resolve(result);
+                return;
+            }
+
+            boolean nullFilter = filter == null;
+            String minTimestamp = !nullFilter && filter.hasKey("minTimestamp") ? filter.getString("minTimestamp") : "0";
+            String maxTimestamp = !nullFilter && filter.hasKey("maxTimestamp") ? filter.getString("maxTimestamp") : "-1";
+            String phoneNumbers = !nullFilter && filter.hasKey("phoneNumbers") ? filter.getString("phoneNumbers") : "[]";
+            JSONArray phoneNumbersArray= new JSONArray(phoneNumbers);
+
+            Set<String> phoneNumberSet = new HashSet<>(Arrays.asList(toStringArray(phoneNumbersArray)));
+
+            int callLogCount = 0;
+
+            final int NUMBER_COLUMN_INDEX = cursor.getColumnIndex(Calls.NUMBER);
+            final int TYPE_COLUMN_INDEX = cursor.getColumnIndex(Calls.TYPE);
+            final int DATE_COLUMN_INDEX = cursor.getColumnIndex(Calls.DATE);
+            final int DURATION_COLUMN_INDEX = cursor.getColumnIndex(Calls.DURATION);
+            final int NAME_COLUMN_INDEX = cursor.getColumnIndex(Calls.CACHED_NAME);
+
+            boolean minTimestampDefined = minTimestamp != null && !minTimestamp.equals("0");
+            boolean minTimestampReached = false;
+
+            while (cursor.moveToNext() && this.shouldContinue(limit, callLogCount) && !minTimestampReached) {
+                String phoneNumber = cursor.getString(NUMBER_COLUMN_INDEX);
+                int duration = cursor.getInt(DURATION_COLUMN_INDEX);
+                String name = cursor.getString(NAME_COLUMN_INDEX);
+
+                String timestampStr = cursor.getString(DATE_COLUMN_INDEX);
+                minTimestampReached = minTimestampDefined && Long.parseLong(timestampStr) <= Long.parseLong(minTimestamp);
+
+                DateFormat df = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM);
+                //DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+                String dateTime = df.format(new Date(Long.valueOf(timestampStr)));
+
+                String type = this.resolveCallType(cursor.getInt(TYPE_COLUMN_INDEX));
+
+                boolean passesPhoneFilter = phoneNumberSet == null || phoneNumberSet.isEmpty() || phoneNumberSet.contains(phoneNumber);
+                boolean passesMinTimestampFilter = minTimestamp == null || minTimestamp.equals("0") || Long.parseLong(timestampStr) >= Long.parseLong(minTimestamp);
+                boolean passesMaxTimestampFilter = maxTimestamp == null || maxTimestamp.equals("-1") || Long.parseLong(timestampStr) <= Long.parseLong(maxTimestamp);
+                boolean passesFilter = passesPhoneFilter&& passesMinTimestampFilter && passesMaxTimestampFilter;
+
+                if (passesFilter) {
+                    WritableMap callLog = Arguments.createMap();
+                    callLog.putString("phoneNumber", phoneNumber);
+                    callLog.putInt("duration", duration);
+                    callLog.putString("name", name);
+                    callLog.putString("timestamp", timestampStr);
+                    callLog.putString("dateTime", dateTime);
+                    callLog.putString("type", type);
+                    callLog.putInt("rawType", cursor.getInt(TYPE_COLUMN_INDEX));
+                    result.pushMap(callLog);
+                    callLogCount++;
+                }
+            }
+
+            cursor.close();
+
             promise.resolve(result);
-            return;
+        } catch (JSONException e) {
+            promise.reject(e);
         }
+    }
 
-        int callLogCount = 0;
+    public static String[] toStringArray(JSONArray array) {
+        if(array==null)
+            return null;
 
-        final int NUMBER_COLUMN_INDEX = cursor.getColumnIndex(Calls.NUMBER);
-        final int TYPE_COLUMN_INDEX = cursor.getColumnIndex(Calls.TYPE);
-        final int DATE_COLUMN_INDEX = cursor.getColumnIndex(Calls.DATE);
-        final int DURATION_COLUMN_INDEX = cursor.getColumnIndex(Calls.DURATION);
-        final int NAME_COLUMN_INDEX = cursor.getColumnIndex(Calls.CACHED_NAME);
-
-        while (cursor.moveToNext() && this.shouldContinue(limit, callLogCount++)) {
-            String phoneNumber = cursor.getString(NUMBER_COLUMN_INDEX);
-            int duration = cursor.getInt(DURATION_COLUMN_INDEX);
-            String name = cursor.getString(NAME_COLUMN_INDEX);
-
-            String timestampStr = cursor.getString(DATE_COLUMN_INDEX);
-            DateFormat df = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM);
-            //DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            String dateTime = df.format(new Date(Long.valueOf(timestampStr)));
-
-            String type = this.resolveCallType(cursor.getInt(TYPE_COLUMN_INDEX));
-
-            WritableMap callLog = Arguments.createMap();
-            callLog.putString("phoneNumber", phoneNumber);
-            callLog.putInt("duration", duration);
-            callLog.putString("name", name);
-            callLog.putString("timestamp", timestampStr);
-            callLog.putString("dateTime", dateTime);
-            callLog.putString("type", type);
-            callLog.putInt("rawType", cursor.getInt(TYPE_COLUMN_INDEX));
-
-            result.pushMap(callLog);
+        String[] arr=new String[array.length()];
+        for(int i=0; i<arr.length; i++) {
+            arr[i]=array.optString(i);
         }
-
-        cursor.close();
-
-        promise.resolve(result);
+        return arr;
     }
 
     private String resolveCallType(int callTypeCode) {

--- a/callLogs.js
+++ b/callLogs.js
@@ -1,3 +1,25 @@
 import { NativeModules } from 'react-native';
 
-module.exports = NativeModules.CallLogs;
+const {CallLogs: NativeCallLogs} = NativeModules
+
+class CallLogs {
+  static async load(limit, filter) {
+    if (!filter) return NativeCallLogs.load(limit)
+    const {minTimestamp, maxTimestamp, phoneNumbers} = filter
+    const phoneNumbersArray = Array.isArray(phoneNumbers) ? phoneNumbers : typeof phoneNumbers === 'string' ? [phoneNumbers] : []
+    return NativeCallLogs.loadWithFilter(
+      limit,
+      {
+        minTimestamp: minTimestamp ? minTimestamp.toString() : undefined,
+        maxTimestamp: maxTimestamp ? maxTimestamp.toString() : undefined,
+        phoneNumbers: JSON.stringify(phoneNumbersArray)
+      }
+    )
+  }
+
+  static async loadAll() {
+    return NativeCallLogs.loadAll()
+  }
+}
+
+module.exports = CallLogs;


### PR DESCRIPTION
I needed some filters to avoid having to fetch the entire list of call logs and filter on the result. (To be precise I needed minTimestamp, maxTimestamp was then straightforward to implement, and I saw that someone else (https://github.com/wscodelabs/react-native-call-log/issues/20) needed to filter by phone numbers so I also implemented it)

I made sure these filters are non breaking so the methods can be used in the same way as before.

To summarize what these filters do and how to use them, I added this to the docs:

```
...
/* List call logs matching the filter */
const filter = {
  minTimestamp: 1571835032,    // (Number or String) timestamp in milliseconds since UNIX epoch
                               // if this filter is set, load(limit, filter) will only return call logs with timestamp >= minTimestamp

  maxTimestamp: 1571835033,    // (Number or String) timestamp in milliseconds since UNIX epoch
                               //
                               // if this filter is set, load(limit, filter) will only return call logs with timestamp <= maxTimestamp

  phoneNumbers: '+1234567890', // (String or an Array of String)
                               // if this filter is set, load(limit, filter) will only return call logs for this/these phone numbers
}

const callLogs = await CallLogs.load(-1, filter) // applies filter with no limit (also works with a limit)
...
```

PS: this is in big part inspired by how the same kind of filtering is done in this other very useful module https://github.com/briankabiro/react-native-get-sms-android