### PR TITLE
Move from JCenter to Maven Central

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.2")
@@ -32,7 +32,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -35,7 +35,7 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
[On February 1, 2022 JCenter will stop adding new packages and be a read-only repository](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). It is already unreliable and was offline today, resulting in a compile error. Therefore, we should use the mavenCentral() repo.